### PR TITLE
Fix errors for servers not using CC plus names

### DIFF
--- a/CustomModels/CustomModels.cs
+++ b/CustomModels/CustomModels.cs
@@ -147,8 +147,9 @@ namespace MCGalaxy {
 
             // initialize because of a late plugin load
             foreach (Player p in PlayerInfo.Online.Items) {
-                SentCustomModels.TryAdd(p.name, new HashSet<string>(StringComparer.OrdinalIgnoreCase));
-                ModelNameToIdForPlayer.TryAdd(p.name, new ConcurrentDictionary<string, byte>(StringComparer.OrdinalIgnoreCase));
+                var isPlus = Server.Config.ClassicubeAccountPlus ? p.name : p.truename;
+                SentCustomModels.TryAdd(isPlus, new HashSet<string>(StringComparer.OrdinalIgnoreCase));
+                ModelNameToIdForPlayer.TryAdd(isPlus, new ConcurrentDictionary<string, byte>(StringComparer.OrdinalIgnoreCase));
             }
         }
 

--- a/CustomModels/StoredCustomModel.cs
+++ b/CustomModels/StoredCustomModel.cs
@@ -514,7 +514,8 @@ namespace MCGalaxy {
 
         static byte? GetModelId(Player p, string name, bool addNew = false) {
             lock (ModelNameToIdForPlayer) {
-                var modelNameToId = ModelNameToIdForPlayer[p.name];
+                var isPlus = Server.Config.ClassicubeAccountPlus ? p.name : p.truename;
+                var modelNameToId = ModelNameToIdForPlayer[isPlus];
                 if (modelNameToId.TryGetValue(name, out byte value)) {
                     return value;
                 } else {
@@ -540,7 +541,8 @@ namespace MCGalaxy {
             if (hasV1 || hasV2) {
 
                 var modelId = GetModelId(p, model.name, true).Value;
-                Debug("DefineModel {0} {1} {2}", modelId, p.name, model.name);
+                var isPlus = Server.Config.ClassicubeAccountPlus ? p.name : p.truename;
+                Debug("DefineModel {0} {1} {2}", modelId, isPlus, model.name);
 
                 model.partCount = (byte)parts.Length;
                 byte[] modelPacket = Packet.DefineModel(modelId, model);
@@ -562,12 +564,13 @@ namespace MCGalaxy {
                 bool hasV2 = p.Supports(CpeExt.CustomModels, 2);
                 if (hasV1 || hasV2) {
                     var modelId = GetModelId(p, name).Value;
-                    Debug("UndefineModel {0} {1} {2}", modelId, p.name, name);
+                    var isPlus = Server.Config.ClassicubeAccountPlus ? p.name : p.truename;
+                    Debug("UndefineModel {0} {1} {2}", modelId, isPlus, name);
 
                     byte[] modelPacket = Packet.UndefineModel(modelId);
                     p.Send(modelPacket);
 
-                    var modelNameToId = ModelNameToIdForPlayer[p.name];
+                    var modelNameToId = ModelNameToIdForPlayer[isPlus];
                     modelNameToId.TryRemove(name, out _);
                 }
             }


### PR DESCRIPTION
Due to the fact you were using p.name here, this would suggest that all usernames have the ClassiCube + after it. If a player was found in the database to use a plus with a similar name as without, it did not compensate.

This commit really just replaces all p.name values with a locally-introduced isPlus variable which fixes all issues.

Tested with both + names on and off and no issues.