### PR TITLE
Fix the dictionary error once and for all

### DIFF
--- a/CustomModels/CustomModels.cs
+++ b/CustomModels/CustomModels.cs
@@ -125,7 +125,7 @@ namespace MCGalaxy {
             command = new CmdCustomModel();
             Command.Register(command);
 
-            OnPlayerConnectEvent.Register(OnPlayerConnect, Priority.Low);
+            OnPlayerFinishConnectingEvent.Register(OnPlayerFinishConnecting, Priority.Low);
             OnPlayerDisconnectEvent.Register(OnPlayerDisconnect, Priority.Low);
             OnJoiningLevelEvent.Register(OnJoiningLevel, Priority.Low);
             OnJoinedLevelEvent.Register(OnJoinedLevel, Priority.Low);
@@ -147,8 +147,8 @@ namespace MCGalaxy {
 
             // initialize because of a late plugin load
             foreach (Player p in PlayerInfo.Online.Items) {
-                SentCustomModels.TryAdd(p.name, new HashSet<string>(StringComparer.OrdinalIgnoreCase));
-                ModelNameToIdForPlayer.TryAdd(p.name, new ConcurrentDictionary<string, byte>(StringComparer.OrdinalIgnoreCase));
+                SentCustomModels.TryAdd(p, new HashSet<string>(StringComparer.OrdinalIgnoreCase));
+                ModelNameToIdForPlayer.TryAdd(p, new ConcurrentDictionary<string, byte>(StringComparer.OrdinalIgnoreCase));
             }
         }
 
@@ -156,7 +156,7 @@ namespace MCGalaxy {
             SentCustomModels.Clear();
             ModelNameToIdForPlayer.Clear();
 
-            OnPlayerConnectEvent.Unregister(OnPlayerConnect);
+            OnPlayerFinishConnectingEvent.Unregister(OnPlayerFinishConnecting);
             OnPlayerDisconnectEvent.Unregister(OnPlayerDisconnect);
             OnJoiningLevelEvent.Unregister(OnJoiningLevel);
             OnJoinedLevelEvent.Unregister(OnJoinedLevel);

--- a/CustomModels/StoredCustomModel.cs
+++ b/CustomModels/StoredCustomModel.cs
@@ -509,12 +509,12 @@ namespace MCGalaxy {
         }
 
 
-        static readonly ConcurrentDictionary<string, ConcurrentDictionary<string, byte>> ModelNameToIdForPlayer =
-            new ConcurrentDictionary<string, ConcurrentDictionary<string, byte>>(StringComparer.OrdinalIgnoreCase);
+        static readonly ConcurrentDictionary<Player, ConcurrentDictionary<string, byte>> ModelNameToIdForPlayer =
+            new ConcurrentDictionary<Player, ConcurrentDictionary<string, byte>>();
 
         static byte? GetModelId(Player p, string name, bool addNew = false) {
             lock (ModelNameToIdForPlayer) {
-                var modelNameToId = ModelNameToIdForPlayer[p.name];
+                var modelNameToId = ModelNameToIdForPlayer[p];
                 if (modelNameToId.TryGetValue(name, out byte value)) {
                     return value;
                 } else {
@@ -567,7 +567,7 @@ namespace MCGalaxy {
                     byte[] modelPacket = Packet.UndefineModel(modelId);
                     p.Send(modelPacket);
 
-                    var modelNameToId = ModelNameToIdForPlayer[p.name];
+                    var modelNameToId = ModelNameToIdForPlayer[p];
                     modelNameToId.TryRemove(name, out _);
                 }
             }


### PR DESCRIPTION
In the OnPlayerDisconnected handler, it calls CheckAddRemove for all players in the same level as the player who was force disconnected, but that's called before the new Player instance has actually had its state added in OnPlayerConnect (so the issue only happens on spawn level).

Credit to Unk for bringing this information to light.